### PR TITLE
additional controls to change the rate and delay of keystrokes in keyboard module

### DIFF
--- a/src/libmsm/ActionDialog.cpp
+++ b/src/libmsm/ActionDialog.cpp
@@ -75,7 +75,8 @@ ActionDialog::startJob()
         m_jobSuccesful = true;
     else
         m_jobSuccesful = false;
-
+    m_terminal->append( QString( "\n" ) );
+    m_terminal->append( QString( tr( "Done ..." ) ) );
     m_buttonBox->setStandardButtons( QDialogButtonBox::Close );
 }
 

--- a/src/modules/kernel/KernelAuthHelper.h
+++ b/src/modules/kernel/KernelAuthHelper.h
@@ -32,6 +32,10 @@ class KernelAuthHelper : public QObject
 public Q_SLOTS:
     ActionReply install( const QVariantMap& args );
     ActionReply remove( const QVariantMap& args );
+
+private:
+    ActionReply runPacman( const QVariantMap& args);
+    ActionReply actionReply;
 };
 
 #endif // KERNELAUTHHELPER_H

--- a/src/modules/kernel/KernelModule.cpp
+++ b/src/modules/kernel/KernelModule.cpp
@@ -134,7 +134,7 @@ PageKernel::installKernel( const QModelIndex& index )
     }
 
     QStringList arguments;
-    arguments << "--noconfirm" << "-S" << packageList;
+    arguments << "--noconfirm" << "--noprogressbar" << "-S" << packageList;
     QVariantMap args;
     args["arguments"] = arguments;
     KAuth::Action installAction( QLatin1String( "org.manjaro.msm.kernel.install" ) );
@@ -171,7 +171,7 @@ PageKernel::removeKernel( const QModelIndex& index )
     }
 
     QStringList arguments;
-    arguments << "--noconfirm" << "-R" << packageList;
+    arguments << "--noconfirm" << "--noprogressbar" << "-R" << packageList;
     QVariantMap args;
     args["arguments"] = arguments;
     KAuth::Action installAction( QLatin1String( "org.manjaro.msm.kernel.remove" ) );

--- a/src/modules/keyboard/KeyboardModule.cpp
+++ b/src/modules/keyboard/KeyboardModule.cpp
@@ -32,6 +32,9 @@
 #include <QtCore/QMapIterator>
 #include <QtWidgets/QMessageBox>
 
+#include <fstream>
+#include <iostream>
+
 #include <QDebug>
 
 #include <KPluginFactory>
@@ -202,6 +205,30 @@ void PageKeyboard::configureKeystroke()
 	char command[100];
 	sprintf(command,"xset r rate %d %d",delay,rate);
 	system(command);
+	//time to make the changes persistant throughout the reboot
+	bool added_to_xinitrc = false;
+	std::ifstream filein("~/.xinitrc");
+	std::string buffer;
+	std::string new_xinitrc;
+	std::string prefix = "xset r rate";
+	while(std::getline(filein,buffer))
+	{
+		qDebug() << buffer.c_str();
+		//condition to check if xset prev defined
+		if(buffer.substr(0,prefix.length()) == prefix){
+			buffer = command;
+			added_to_xinitrc = true;
+		}
+		new_xinitrc = new_xinitrc + buffer + "\n";
+	}
+	filein.close();
+	if(!added_to_xinitrc){
+		new_xinitrc = new_xinitrc + command + "\n";
+	}
+	qDebug() << new_xinitrc.c_str();
+	std::ofstream fileout("~/.xinitrc",std::ios_base::app);
+	fileout.write(new_xinitrc.c_str(),new_xinitrc.length());
+	fileout.close();
 }
 
 void

--- a/src/modules/keyboard/KeyboardModule.cpp
+++ b/src/modules/keyboard/KeyboardModule.cpp
@@ -99,6 +99,24 @@ PageKeyboard::PageKeyboard( QWidget* parent, const QVariantList& args ) :
         this->changed();
     } );
 
+
+	//setting the current values for delay and rate 
+	ui -> sliderDelay -> setValue(this -> getKeyboardDelay());
+	ui -> sliderRate -> setValue(this -> getKeyboardRate());
+	ui -> label_2 -> setText(QString::number(this -> getKeyboardDelay()));
+	ui -> label_3 -> setText(QString::number(this -> getKeyboardRate()));
+	//adding signals and slots for the delay and rate slider 
+	connect( ui -> sliderDelay, &QSlider::valueChanged,
+		[=] ( int value ){
+			ui -> label_2 -> setText(QString::number(value));
+			this -> changed();
+	});
+	connect( ui -> sliderRate, &QSlider::valueChanged,
+		[=] (int value){
+			ui -> label_3 -> setText(QString::number(value));
+			this -> changed();
+	});
+
     m_keyboardProxyModel->setSourceModel( m_keyboardModel );
     m_keyboardProxyModel->setSortLocaleAware( true );
     m_keyboardProxyModel->setSortRole( KeyboardModel::DescriptionRole );
@@ -160,6 +178,7 @@ void
 PageKeyboard::save()
 {
     setKeyboardLayout();
+	configureKeystroke();
 }
 
 
@@ -169,8 +188,21 @@ PageKeyboard::defaults()
     setLayoutsListViewIndex( m_currentLayout );
     setVariantsListViewIndex( m_currentVariant );
     setModelComboBoxIndex( m_currentModel );
+	ui -> sliderDelay -> setValue(this -> getKeyboardDelay());
+	ui -> sliderRate -> setValue(this -> getKeyboardRate());
+	ui -> label_2 -> setText(QString::number(this -> getKeyboardDelay()));
+	ui -> label_3 -> setText(QString::number(this -> getKeyboardRate()));
 }
 
+
+void PageKeyboard::configureKeystroke()
+{
+	int delay = ui -> sliderDelay -> value();
+	int rate  = ui -> sliderRate  -> value();
+	char command[100];
+	sprintf(command,"xset r rate %d %d",delay,rate);
+	system(command);
+}
 
 void
 PageKeyboard::setKeyboardLayout()
@@ -283,6 +315,22 @@ PageKeyboard::setModelComboBoxIndex( const QString& model )
     }
     else
         qDebug() << QString( "Can't find the keyboard model %1" ).arg( model );
+}
+
+int PageKeyboard::getKeyboardDelay(){
+	FILE * file = popen("xset q | grep rate","r");
+	int delay,rate;
+	fscanf(file,"%*[^0123456789]%d%*[^0123456789]%d",&delay,&rate);
+	pclose(file);
+	return delay;
+}
+
+int PageKeyboard::getKeyboardRate(){
+	FILE * file = popen("xset q | grep rate","r");
+	int delay,rate;
+	fscanf(file,"%*[^0123456789]%d%*[^0123456789]%d",&delay,&rate);
+	pclose(file);
+	return rate;
 }
 
 #include "KeyboardModule.moc"

--- a/src/modules/keyboard/KeyboardModule.h
+++ b/src/modules/keyboard/KeyboardModule.h
@@ -78,9 +78,13 @@ private:
     QString m_currentModel;
 
     void setKeyboardLayout();
+	void configureKeystroke();
     void setLayoutsListViewIndex( const QString& layout );
     void setVariantsListViewIndex( const QString& variant );
     void setModelComboBoxIndex( const QString& model );
+
+	int getKeyboardRate();
+	int getKeyboardDelay();
 };
 
 #endif // KEYBOARDMODULE_H

--- a/src/modules/keyboard/ui/PageKeyboard.ui
+++ b/src/modules/keyboard/ui/PageKeyboard.ui
@@ -56,6 +56,77 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Delay</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Delay</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="sliderDelay">
+       <property name="toolTip">
+        <string>Set delay</string>
+       </property>
+       <property name="minimum">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <number>1000</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_5">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Rate  </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Rate  </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSlider" name="sliderRate">
+       <property name="toolTip">
+        <string>Set Rate</string>
+       </property>
+       <property name="minimum">
+        <number>5</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_4">
      <item>
       <widget class="QListView" name="layoutsListView"/>


### PR DESCRIPTION
I noticed that current settings manager did not provide controls to change the typing rate and set delay for keystrokes unlike what i found in mint (screenshot for mint 
![keyboard](https://cloud.githubusercontent.com/assets/3060481/10040344/4ac1c1e6-61f8-11e5-8b82-6952a52d9aa7.jpg)
) This patch takes care of this issue. Although the UI might need some tweeks.