### PR TITLE
(almost) added rt-lts kernel

### DIFF
--- a/src/libmsm/KernelModel.cpp
+++ b/src/libmsm/KernelModel.cpp
@@ -342,7 +342,7 @@ KernelModel::getRunningKernel() const
     uname.waitForFinished();
     QString result = uname.readAllStandardOutput();
     uname.close();
-    if ( result.contains( "-rt" ) )
+    if ( result.contains( "-rt-manjaro" ) )
         return "linux-rt-manjaro";
     else if ( result.contains( "-rt-lts" ) )
         return "linux-rt-lts-manjaro";

--- a/src/libmsm/KernelModel.cpp
+++ b/src/libmsm/KernelModel.cpp
@@ -51,15 +51,15 @@ KernelModel::update()
     QStringList recommendedKernels = getRecommendedKernels();
 
     QSet<QString> modulesToInstall;
-    foreach ( const QString& module, QStringList( installedKernelPackages.keys() ).filter( QRegularExpression( "^linux([0-9][0-9]?([0-9])|-rt-manjaro)-" ) ) )
+    foreach ( const QString& module, QStringList( installedKernelPackages.keys() ).filter( QRegularExpression( "^linux([0-9][0-9]?([0-9])|-rt-manjaro|-rt-lts-manjaro)-" ) ) )
     {
-        QString aux = QString( module ).remove( QRegularExpression( "^linux([0-9][0-9]?([0-9])|-rt-manjaro)-" ) );
+        QString aux = QString( module ).remove( QRegularExpression( "^linux([0-9][0-9]?([0-9])|-rt-manjaro|-rt-lts-manjaro)-" ) );
         modulesToInstall.insert( aux );
     }
 
     beginResetModel();
     m_kernels.clear();
-    foreach ( const QString& kernel, QStringList( allKernelPackages.keys() ).filter( QRegularExpression( "^linux([0-9][0-9]?([0-9])|-rt-manjaro)$" ) ) )
+    foreach ( const QString& kernel, QStringList( allKernelPackages.keys() ).filter( QRegularExpression( "^linux([0-9][0-9]?([0-9])|-rt-manjaro|-rt-lts-manjaro)$" ) ) )
     {
         Kernel newKernel;
 
@@ -207,7 +207,7 @@ KernelModel::getAvailablePackages() const
 {
     QProcess process;
     process.setEnvironment( QStringList() << "LANG=C" << "LC_MESSAGES=C" );
-    process.start( "pacman", QStringList() << "-Ss" << "^linux([0-9][0-9]?([0-9])|-rt-manjaro)" );
+    process.start( "pacman", QStringList() << "-Ss" << "^linux([0-9][0-9]?([0-9])|-rt-manjaro|-rt-lts-manjaro)" );
     if ( !process.waitForFinished( 15000 ) )
         qDebug() << "error: failed to get installed kernels";
     QString result = process.readAllStandardOutput();
@@ -235,7 +235,7 @@ KernelModel::getInstalledPackages() const
 {
     QProcess process;
     process.setEnvironment( QStringList() << "LANG=C" << "LC_MESSAGES=C" );
-    process.start( "pacman", QStringList() << "-Qs" << "^linux([0-9][0-9]?([0-9])|-rt-manjaro)" );
+    process.start( "pacman", QStringList() << "-Qs" << "^linux([0-9][0-9]?([0-9])|-rt-manjaro|-rt-lts-manjaro)" );
     if ( !process.waitForFinished( 15000 ) )
         qDebug() << "error: failed to get installed kernels";
     QString result = process.readAll();
@@ -344,6 +344,8 @@ KernelModel::getRunningKernel() const
     uname.close();
     if ( result.contains( "-rt" ) )
         return "linux-rt-manjaro";
+    else if ( result.contains( "-rt-lts" ) )
+        return "linux-rt-lts-manjaro";
     else
     {
         QStringList aux = result.split( ".", QString::SkipEmptyParts );

--- a/src/libmsm/KernelModel.cpp
+++ b/src/libmsm/KernelModel.cpp
@@ -342,7 +342,7 @@ KernelModel::getRunningKernel() const
     uname.waitForFinished();
     QString result = uname.readAllStandardOutput();
     uname.close();
-    if ( result.contains( "-rt-manjaro" ) )
+    if ( result.contains( "-rt" ) )
         return "linux-rt-manjaro";
     else if ( result.contains( "-rt-lts" ) )
         return "linux-rt-lts-manjaro";


### PR DESCRIPTION
Tested locally. Works as expected for kernel listing and recognition of installed rt-lts as "realtime".
Doesn't work - as is also to be expected ;) - to detect rt-lts as running kernel, since ``uname -r`` returns ``4.4.15-1-rt23-MANJARO``
I need a little help there...