### PR TITLE
TimeDate: Fix "Apply" button enabling for checkbox options (fixes #111)

### DIFF
--- a/src/modules/timedate/TimeDateCommon.cpp
+++ b/src/modules/timedate/TimeDateCommon.cpp
@@ -91,6 +91,7 @@ void
 TimeDateCommon::updateUi( Ui::PageTimeDate* ui, TimeDateService* timeDateService,
                           bool isTimeEdited, bool isDateEdited, QString currentTimeZone )
 {
+    ui->isNtpEnabledCheckBox->blockSignals( true );
     if ( timeDateService->canNtp() )
         ui->isNtpEnabledCheckBox->setChecked( timeDateService->isNtpEnabled() );
     else
@@ -98,8 +99,11 @@ TimeDateCommon::updateUi( Ui::PageTimeDate* ui, TimeDateService* timeDateService
         ui->isNtpEnabledCheckBox->setChecked( false );
         ui->isNtpEnabledCheckBox->setEnabled( false );
     }
+    ui->isNtpEnabledCheckBox->blockSignals( false );
 
+    ui->isRtcLocalCheckBox->blockSignals( true );
     ui->isRtcLocalCheckBox->setChecked( timeDateService->isRtcInLocalTimeZone() );
+    ui->isRtcLocalCheckBox->blockSignals( false );
 
     QTimeZone timeZone = QTimeZone( currentTimeZone.toLatin1() );
     if ( timeZone.isValid() )

--- a/src/modules/timedate/TimeDatePage.cpp
+++ b/src/modules/timedate/TimeDatePage.cpp
@@ -52,6 +52,7 @@ TimeDatePage::TimeDatePage( QWidget* parent ) :
     {
         ui->timeEdit->setEnabled( !checked );
         ui->dateEdit->setEnabled( !checked );
+        this -> setApplyEnabled( this, true );
     } );
     connect( ui->timeZonePushButton, &QPushButton::clicked,
              [=] ( bool checked )


### PR DESCRIPTION
Fixes #111.

`setApplyEnabled( this, true )` call was missing inside `isNtpEnabledCheckBox`'s `toggled` signal handler.

Signals are now blocked during initial values setup to prevent firing of unwanted `QCheckBox::toggled` signal and therefore making Apply button visible even if user doesn't make any changes.

Issue was fixed even for `isRtcLocalCheckBox`.