### PR TITLE
Notifier consolidation

### DIFF
--- a/src/notifier/notifier/Notifier.cpp
+++ b/src/notifier/notifier/Notifier.cpp
@@ -87,7 +87,7 @@ Notifier::Notifier( QObject* parent ) :
     connect( optionsAction, &QAction::triggered,
              [this] ()
     {
-        m_settingsDialog = new NotifierSettingsDialog( NULL );
+        NotifierSettingsDialog* m_settingsDialog = new NotifierSettingsDialog( NULL );
         m_settingsDialog->setAttribute( Qt::WidgetAttribute::WA_DeleteOnClose, true );
         m_settingsDialog->exec();
     } );
@@ -123,7 +123,8 @@ Notifier::Notifier( QObject* parent ) :
 
 Notifier::~Notifier()
 {
-
+    delete m_tray;
+    delete m_timer;
 }
 
 

--- a/src/notifier/notifier/Notifier.cpp
+++ b/src/notifier/notifier/Notifier.cpp
@@ -2,6 +2,7 @@
  *  This file is part of Manjaro Settings Manager.
  *
  *  Ramon Buldó <ramon@manjaro.org>
+ *  Kacper Piwiński
  *
  *  Manjaro Settings Manager is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -36,27 +37,26 @@
 Notifier::Notifier( QObject* parent ) :
     QObject( parent )
 {
-
-
     m_tray = new QSystemTrayIcon( this );
     m_tray->setIcon( QIcon::fromTheme( "manjaro-settings-manager" ) );
 
     QMenu* menu = new QMenu();
     m_tray->setContextMenu( menu );
+
     QAction* msmKernel = new QAction( QIcon( ":/icons/tux-manjaro.png" ),
-                                      QString( tr ( "Kernels" ) ),
+                                      tr ( "Kernels" ),
                                       menu );
     QAction* msmLanguagePackages = new QAction(
         QIcon( ":/icons/language.png" ),
-        QString( tr ( "Language packages" ) ),
+        tr ( "Language packages" ),
         menu );
     QAction* quitAction = new QAction(
         QIcon::fromTheme( "application-exit"  ),
-        QString( tr ( "Quit" ) ),
+        tr ( "Quit" ),
         menu );
     QAction* optionsAction = new QAction(
         QIcon::fromTheme( "gtk-preferences"  ),
-        QString( tr ( "Options" ) ),
+        tr ( "Options" ),
         menu );
 
     menu->addAction( msmKernel );
@@ -65,23 +65,27 @@ Notifier::Notifier( QObject* parent ) :
     menu->addSeparator();
     menu->addAction( quitAction );
 
-    connect( msmKernel, &QAction::triggered, this, [msmKernel, this]()
+    connect( msmKernel, &QAction::triggered,
+             [this] ()
     {
         QProcess::startDetached( "manjaro-settings-manager", QStringList() << "-m" << "msm_kernel" );
         m_tray->hide();
     } );
-    connect( msmLanguagePackages, &QAction::triggered, this, [msmLanguagePackages, this]()
+    connect( msmLanguagePackages, &QAction::triggered,
+             [this] ()
     {
         QProcess::startDetached( "manjaro-settings-manager", QStringList() << "-m" << "msm_language_packages" );
         m_tray->hide();
     } );
 
-    connect( quitAction, &QAction::triggered, this, [quitAction, this]()
+    connect( quitAction, &QAction::triggered,
+             [this] ()
     {
         qApp->quit();
     } );
 
-    connect( optionsAction, &QAction::triggered, this, [optionsAction, this]()
+    connect( optionsAction, &QAction::triggered,
+             [this] ()
     {
         m_settingsDialog = new NotifierSettingsDialog( NULL );
         m_settingsDialog->setAttribute( Qt::WidgetAttribute::WA_DeleteOnClose, true );
@@ -93,7 +97,8 @@ Notifier::Notifier( QObject* parent ) :
     m_timer->setInterval( 60 * 1000 );
     m_timer->start();
 
-    connect( m_timer, &QTimer::timeout, [=] ()
+    connect( m_timer, &QTimer::timeout,
+             [this] ()
     {
         loadConfiguration();
         if ( !PacmanUtils::isPacmanUpdating() && PacmanUtils::hasPacmanEverSynced() )
@@ -189,7 +194,7 @@ Notifier::cLanguagePackage()
         qDebug() << "Missing language packages found, notifying user...";
         m_tray->show();
         m_tray->showMessage( tr( "Manjaro Settings Manager" ),
-                             QString( tr( "%n new additional language package(s) available", "", packageNumber ) ),
+                             tr( "%n new additional language package(s) available", "", packageNumber ),
                              QSystemTrayIcon::Information,
                              10000 );
 
@@ -227,16 +232,16 @@ Notifier::cKernel()
         if ( foundRunning )
         {
             m_tray->show();
-            m_tray->showMessage( QString( tr( "Manjaro Settings Manager" ) ),
-                                 QString( tr( "Running an unsupported kernel, please update." ) ),
+            m_tray->showMessage( tr( "Manjaro Settings Manager" ),
+                                 tr( "Running an unsupported kernel, please update." ),
                                  QSystemTrayIcon::Warning,
                                  10000 );
         }
         else if ( found )
         {
             m_tray->show();
-            m_tray->showMessage( QString( tr( "Manjaro Settings Manager" ) ),
-                                 QString( tr( "Unsupported kernel installed in your system, please remove it." ) ),
+            m_tray->showMessage( tr( "Manjaro Settings Manager" ),
+                                 tr( "Unsupported kernel installed in your system, please remove it." ),
                                  QSystemTrayIcon::Information,
                                  10000 );
         }
@@ -288,8 +293,8 @@ Notifier::cKernel()
 void Notifier::showNewKernelNotification()
 {
     m_tray->show();
-    m_tray->showMessage( QString( tr( "Manjaro Settings Manager" ) ),
-                         QString( tr( "Newer kernel is available, please update." ) ),
+    m_tray->showMessage( tr( "Manjaro Settings Manager" ),
+                         tr( "Newer kernel is available, please update." ),
                          QSystemTrayIcon::Information,
                          10000 );
 }

--- a/src/notifier/notifier/Notifier.h
+++ b/src/notifier/notifier/Notifier.h
@@ -37,7 +37,6 @@ public:
 private:
     QSystemTrayIcon* m_tray;
     QTimer* m_timer;
-    NotifierSettingsDialog* m_settingsDialog;
     bool m_checkLanguagePackage;
     bool m_checkKernel;
     bool m_checkUnsupportedKernel;

--- a/src/notifier/notifier/NotifierApp.cpp
+++ b/src/notifier/notifier/NotifierApp.cpp
@@ -2,6 +2,7 @@
  *  This file is part of Manjaro Settings Manager.
  *
  *  Ramon Buldó <ramon@manjaro.org>
+ *  Kacper Piwiński
  *
  *  Manjaro Settings Manager is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/src/notifier/notifier/NotifierApp.h
+++ b/src/notifier/notifier/NotifierApp.h
@@ -37,4 +37,3 @@ public:
 };
 
 #endif //NOTIFIERAPP_H
-

--- a/src/notifier/notifier/main.cpp
+++ b/src/notifier/notifier/main.cpp
@@ -2,6 +2,7 @@
  *  This file is part of Manjaro Settings Manager.
  *
  *  Ramon Buldó <ramon@manjaro.org>
+ *  Kacper Piwiński
  *
  *  Manjaro Settings Manager is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -54,23 +55,20 @@ int main( int argc, char* argv[] )
     {
         NotifierSettingsDialog* m_settingsDialog = new NotifierSettingsDialog( NULL );
         m_settingsDialog->setAttribute( Qt::WidgetAttribute::WA_DeleteOnClose, true );
-        m_settingsDialog->exec();
-        return 0;
+        return m_settingsDialog->exec();
     }
 
     // ensure only one tray icon application is runnung
     KDSingleApplicationGuard guard( KDSingleApplicationGuard::AutoKillOtherInstances );
 
-    int returnCode = 0;
     if ( guard.isPrimaryInstance() )
     {
         app.init();
         Notifier notifier( &app );
-        returnCode = app.exec();
+        return app.exec();
     }
     else
         qDebug() << "MSM Notifier is already running, shutting down.";
 
-    return returnCode;
+    return 0;
 }
-

--- a/src/notifier/notifier/main.cpp
+++ b/src/notifier/notifier/main.cpp
@@ -68,7 +68,9 @@ int main( int argc, char* argv[] )
         return app.exec();
     }
     else
+    {
         qDebug() << "MSM Notifier is already running, shutting down.";
+    }
 
     return 0;
 }

--- a/src/notifier/notifier_kde/Notifier.cpp
+++ b/src/notifier/notifier_kde/Notifier.cpp
@@ -76,7 +76,7 @@ Notifier::Notifier( QObject* parent ) :
     connect( optionsAction, &QAction::triggered,
              [this] ()
     {
-        m_settingsDialog = new NotifierSettingsDialog( NULL );
+        NotifierSettingsDialog* m_settingsDialog = new NotifierSettingsDialog( NULL );
         m_settingsDialog->setAttribute( Qt::WidgetAttribute::WA_DeleteOnClose, true );
         m_settingsDialog->exec();
     } );
@@ -112,7 +112,8 @@ Notifier::Notifier( QObject* parent ) :
 
 Notifier::~Notifier()
 {
-
+    delete m_tray;
+    delete m_timer;
 }
 
 

--- a/src/notifier/notifier_kde/Notifier.cpp
+++ b/src/notifier/notifier_kde/Notifier.cpp
@@ -2,6 +2,7 @@
  *  This file is part of Manjaro Settings Manager.
  *
  *  Ramon Buldó <ramon@manjaro.org>
+ *  Kacper Piwiński
  *
  *  Manjaro Settings Manager is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -37,44 +38,46 @@ Notifier::Notifier( QObject* parent ) :
     QObject( parent )
 {
     m_tray = new KStatusNotifierItem( this );
-    m_tray->setTitle( QString( tr ( "Manjaro Settings Manager" ) ) );
+    m_tray->setTitle( tr ( "Manjaro Settings Manager" ) );
     m_tray->setIconByName( "manjaro-settings-manager" );
-    m_tray->setStatus( KStatusNotifierItem::Passive );
 
-    auto menu = m_tray->contextMenu();
+    QMenu* menu = m_tray->contextMenu();
 
     QAction* msmKernel = new QAction( QIcon( ":/icons/tux-manjaro.png" ),
-                                      QString( tr ( "Kernels" ) ),
+                                      tr ( "Kernels" ),
                                       menu );
     QAction* msmLanguagePackages = new QAction(
         QIcon( ":/icons/language.png" ),
-        QString( tr ( "Language packages" ) ),
+        tr ( "Language packages" ),
         menu );
 
     QAction* optionsAction = new QAction(
         QIcon::fromTheme( "gtk-preferences"  ),
-        QString( tr ( "Options" ) ),
+        tr ( "Options" ),
         menu );
 
     menu->addAction( msmKernel );
     menu->addAction( msmLanguagePackages );
     menu->addAction( optionsAction );
 
-    connect( msmKernel, &QAction::triggered, this, [msmKernel, this]()
+    connect( msmKernel, &QAction::triggered,
+             [this] ()
     {
         QProcess::startDetached( "manjaro-settings-manager", QStringList() << "-m" << "msm_kernel" );
         m_tray->setStatus( KStatusNotifierItem::Passive );
     } );
-    connect( msmLanguagePackages, &QAction::triggered, this, [msmLanguagePackages, this]()
+    connect( msmLanguagePackages, &QAction::triggered,
+             [this] ()
     {
         QProcess::startDetached( "manjaro-settings-manager", QStringList() << "-m" << "msm_language_packages" );
         m_tray->setStatus( KStatusNotifierItem::Passive );
     } );
 
-    connect( optionsAction, &QAction::triggered, this, [optionsAction, this]()
+    connect( optionsAction, &QAction::triggered,
+             [this] ()
     {
-        m_settingsDialog = new NotifierSettingsDialog(NULL);
-        m_settingsDialog->setAttribute(Qt::WidgetAttribute::WA_DeleteOnClose, true);
+        m_settingsDialog = new NotifierSettingsDialog( NULL );
+        m_settingsDialog->setAttribute( Qt::WidgetAttribute::WA_DeleteOnClose, true );
         m_settingsDialog->exec();
     } );
 
@@ -83,7 +86,8 @@ Notifier::Notifier( QObject* parent ) :
     m_timer->setInterval( 60 * 1000 );
     m_timer->start();
 
-    connect( m_timer, &QTimer::timeout, [=] ()
+    connect( m_timer, &QTimer::timeout,
+             [this] ()
     {
         loadConfiguration();
         if ( !PacmanUtils::isPacmanUpdating() && PacmanUtils::hasPacmanEverSynced() )
@@ -179,8 +183,8 @@ Notifier::cLanguagePackage()
         qDebug() << "Missing language packages found, notifying user...";
         m_tray->setStatus( KStatusNotifierItem::Active );
         m_tray->showMessage( tr( "Manjaro Settings Manager" ),
-                             QString( tr( "%n new additional language package(s) available", "", packageNumber ) ),
-                             QString( "dialog-information" ),
+                             tr( "%n new additional language package(s) available", "", packageNumber ),
+                             "dialog-information",
                              10000 );
 
         // Add to Config
@@ -217,17 +221,17 @@ Notifier::cKernel()
         if ( foundRunning )
         {
             m_tray->setStatus( KStatusNotifierItem::Active );
-            m_tray->showMessage( QString( tr( "Manjaro Settings Manager" ) ),
-                                 QString( tr( "Running an unsupported kernel, please update." ) ),
-                                 QString( "dialog-warning" ),
+            m_tray->showMessage( tr( "Manjaro Settings Manager" ),
+                                 tr( "Running an unsupported kernel, please update." ),
+                                 "dialog-warning",
                                  10000 );
         }
         else if ( found )
         {
             m_tray->setStatus( KStatusNotifierItem::Active );
-            m_tray->showMessage( QString( tr( "Manjaro Settings Manager" ) ),
-                                 QString( tr( "Unsupported kernel installed in your system, please remove it." ) ),
-                                 QString( "dialog-information" ),
+            m_tray->showMessage( tr( "Manjaro Settings Manager" ),
+                                 tr( "Unsupported kernel installed in your system, please remove it." ),
+                                 "dialog-information",
                                  10000 );
         }
     }
@@ -278,9 +282,9 @@ Notifier::cKernel()
 void Notifier::showNewKernelNotification()
 {
     m_tray->setStatus( KStatusNotifierItem::Active );
-    m_tray->showMessage( QString( tr( "Manjaro Settings Manager" ) ),
-                         QString( tr( "Newer kernel is available, please update." ) ),
-                         QString( "dialog-information" ),
+    m_tray->showMessage( tr( "Manjaro Settings Manager" ),
+                         tr( "Newer kernel is available, please update." ),
+                         "dialog-information",
                          10000 );
 }
 

--- a/src/notifier/notifier_kde/Notifier.h
+++ b/src/notifier/notifier_kde/Notifier.h
@@ -23,9 +23,8 @@
 #include "LanguagePackagesItem.h"
 #include "NotifierSettingsDialog.h"
 
-#include <KNotifications/KStatusNotifierItem>
-
 #include <QtCore/QTimer>
+#include <KNotifications/KStatusNotifierItem>
 
 class Notifier : public QObject
 {

--- a/src/notifier/notifier_kde/Notifier.h
+++ b/src/notifier/notifier_kde/Notifier.h
@@ -37,7 +37,6 @@ public:
 private:
     KStatusNotifierItem* m_tray;
     QTimer* m_timer;
-    NotifierSettingsDialog* m_settingsDialog;
     bool m_checkLanguagePackage;
     bool m_checkKernel;
     bool m_checkUnsupportedKernel;

--- a/src/notifier/notifier_kde/NotifierApp.cpp
+++ b/src/notifier/notifier_kde/NotifierApp.cpp
@@ -2,6 +2,7 @@
  *  This file is part of Manjaro Settings Manager.
  *
  *  Ramon Buldó <ramon@manjaro.org>
+ *  Kacper Piwiński
  *
  *  Manjaro Settings Manager is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -30,6 +31,7 @@ NotifierApp::NotifierApp( int& argc, char* argv[] )
     setOrganizationDomain( "Manjaro" );
     setApplicationName( "MSM Notifier for Plasma5" );
     setApplicationVersion( PROJECT_VERSION );
+    setQuitOnLastWindowClosed( false );
 }
 
 

--- a/src/notifier/notifier_kde/NotifierApp.h
+++ b/src/notifier/notifier_kde/NotifierApp.h
@@ -37,4 +37,3 @@ public:
 };
 
 #endif //NOTIFIERAPP_H
-

--- a/src/notifier/notifier_kde/main.cpp
+++ b/src/notifier/notifier_kde/main.cpp
@@ -2,6 +2,7 @@
  *  This file is part of Manjaro Settings Manager.
  *
  *  Ramon Buldó <ramon@manjaro.org>
+ *  Kacper Piwiński
  *
  *  Manjaro Settings Manager is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -24,9 +25,8 @@
 #include <QtWidgets/QApplication>
 #include <QtCore/QTranslator>
 #include <QtCore/QFile>
-#include <QtCore/QCommandLineParser>
 #include <QtCore/QDir>
-
+#include <QtCore/QCommandLineParser>
 #include <QDebug>
 
 int main( int argc, char* argv[] )
@@ -37,6 +37,9 @@ int main( int argc, char* argv[] )
     Q_INIT_RESOURCE( translations );
 
     QCommandLineParser parser;
+    parser.setApplicationDescription( app.applicationName() );
+    parser.addHelpOption();
+
     QCommandLineOption settingsOption( QStringList() << "s" << "settings",
                                     "Show msm notifier options" );
     parser.addOption( settingsOption );
@@ -52,22 +55,20 @@ int main( int argc, char* argv[] )
     {
         NotifierSettingsDialog* m_settingsDialog = new NotifierSettingsDialog( NULL );
         m_settingsDialog->setAttribute( Qt::WidgetAttribute::WA_DeleteOnClose, true );
-        m_settingsDialog->exec();
-        return 0;
+        return m_settingsDialog->exec();
     }
 
+    // ensure only one tray icon application is runnung
     KDSingleApplicationGuard guard( KDSingleApplicationGuard::AutoKillOtherInstances );
 
-    int returnCode = 0;
     if ( guard.isPrimaryInstance() )
     {
         app.init();
         Notifier notifier( &app );
-        returnCode = app.exec();
+        return app.exec();
     }
     else
         qDebug() << "MSM Notifier is already running, shutting down.";
 
-    return returnCode;
+    return 0;
 }
-

--- a/src/notifier/notifier_kde/main.cpp
+++ b/src/notifier/notifier_kde/main.cpp
@@ -68,7 +68,9 @@ int main( int argc, char* argv[] )
         return app.exec();
     }
     else
+    {
         qDebug() << "MSM Notifier is already running, shutting down.";
+    }
 
     return 0;
 }


### PR DESCRIPTION
When I was looking at where notifier saves it's setting I wrote some consolidations code and was thinking about writing some module so there would be only one place with configuration. But then I had some different things to do. 
This patches consolidates code between notifier and notifier_kde.